### PR TITLE
Move items to separate item group tab

### DIFF
--- a/src/generated/resources/assets/moretoolmaterials/lang/en_us.json
+++ b/src/generated/resources/assets/moretoolmaterials/lang/en_us.json
@@ -34,5 +34,6 @@
   "item.moretoolmaterials.redstone_leggings": "Redstone Leggings",
   "item.moretoolmaterials.redstone_pickaxe": "Redstone Pickaxe",
   "item.moretoolmaterials.redstone_shovel": "Redstone Shovel",
-  "item.moretoolmaterials.redstone_sword": "Redstone Sword"
+  "item.moretoolmaterials.redstone_sword": "Redstone Sword",
+  "itemGroup.moretoolmaterials": "More Tool Materials"
 }

--- a/src/main/java/moretoolmaterials/datagen/ModLanguageProvider.java
+++ b/src/main/java/moretoolmaterials/datagen/ModLanguageProvider.java
@@ -61,6 +61,8 @@ public class ModLanguageProvider extends LanguageProvider
         addItem(ArmorRegistry.LAPIS_BOOTS, "Lapis Lazuli Boots");
         addItem(ArmorRegistry.OBSIDIAN_BOOTS, "Obsidian Boots");
         addItem(ArmorRegistry.REDSTONE_BOOTS, "Redstone Boots");
+        
+        add("itemGroup." + MoreToolMaterials.MOD_ID, "More Tool Materials");
     }
 
 }

--- a/src/main/java/moretoolmaterials/item/ModItemGroup.java
+++ b/src/main/java/moretoolmaterials/item/ModItemGroup.java
@@ -1,0 +1,18 @@
+package moretoolmaterials.item;
+
+import moretoolmaterials.MoreToolMaterials;
+import moretoolmaterials.registry.ToolRegistry;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemStack;
+
+public class ModItemGroup extends ItemGroup {
+
+    public ModItemGroup() {
+        super(MoreToolMaterials.MOD_ID);
+    }
+
+    @Override
+    public ItemStack makeIcon() {
+        return new ItemStack(ToolRegistry.REDSTONE_SWORD.get());
+    }
+}

--- a/src/main/java/moretoolmaterials/registry/ArmorRegistry.java
+++ b/src/main/java/moretoolmaterials/registry/ArmorRegistry.java
@@ -2,6 +2,7 @@ package moretoolmaterials.registry;
 
 import moretoolmaterials.MoreToolMaterials;
 import moretoolmaterials.item.ModArmorMaterials;
+import moretoolmaterials.item.ModItemGroup;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ArmorItem;
 import net.minecraft.item.Item;
@@ -12,25 +13,27 @@ import net.minecraftforge.registries.ForgeRegistries;
 
 public class ArmorRegistry
 {
+    public static final ItemGroup ITEM_GROUP = new ModItemGroup();
+    
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MoreToolMaterials.MOD_ID);
 
-    public static final RegistryObject<ArmorItem> EMERALD_HELMET = ITEMS.register("emerald_helmet", () -> new ArmorItem(ModArmorMaterials.EMERALD, EquipmentSlotType.HEAD, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> LAPIS_HELMET = ITEMS.register("lapis_helmet", () -> new ArmorItem(ModArmorMaterials.LAPIS, EquipmentSlotType.HEAD, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> OBSIDIAN_HELMET = ITEMS.register("obsidian_helmet", () -> new ArmorItem(ModArmorMaterials.OBSIDIAN, EquipmentSlotType.HEAD, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> REDSTONE_HELMET = ITEMS.register("redstone_helmet", () -> new ArmorItem(ModArmorMaterials.REDSTONE, EquipmentSlotType.HEAD, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
+    public static final RegistryObject<ArmorItem> EMERALD_HELMET = ITEMS.register("emerald_helmet", () -> new ArmorItem(ModArmorMaterials.EMERALD, EquipmentSlotType.HEAD, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> LAPIS_HELMET = ITEMS.register("lapis_helmet", () -> new ArmorItem(ModArmorMaterials.LAPIS, EquipmentSlotType.HEAD, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> OBSIDIAN_HELMET = ITEMS.register("obsidian_helmet", () -> new ArmorItem(ModArmorMaterials.OBSIDIAN, EquipmentSlotType.HEAD, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> REDSTONE_HELMET = ITEMS.register("redstone_helmet", () -> new ArmorItem(ModArmorMaterials.REDSTONE, EquipmentSlotType.HEAD, (new Item.Properties()).tab(ITEM_GROUP)));
 
-    public static final RegistryObject<ArmorItem> EMERALD_CHESTPLATE = ITEMS.register("emerald_chestplate", () -> new ArmorItem(ModArmorMaterials.EMERALD, EquipmentSlotType.CHEST, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> LAPIS_CHESTPLATE = ITEMS.register("lapis_chestplate", () -> new ArmorItem(ModArmorMaterials.LAPIS, EquipmentSlotType.CHEST, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> OBSIDIAN_CHESTPLATE = ITEMS.register("obsidian_chestplate", () -> new ArmorItem(ModArmorMaterials.OBSIDIAN, EquipmentSlotType.CHEST, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> REDSTONE_CHESTPLATE = ITEMS.register("redstone_chestplate", () -> new ArmorItem(ModArmorMaterials.REDSTONE, EquipmentSlotType.CHEST, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
+    public static final RegistryObject<ArmorItem> EMERALD_CHESTPLATE = ITEMS.register("emerald_chestplate", () -> new ArmorItem(ModArmorMaterials.EMERALD, EquipmentSlotType.CHEST, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> LAPIS_CHESTPLATE = ITEMS.register("lapis_chestplate", () -> new ArmorItem(ModArmorMaterials.LAPIS, EquipmentSlotType.CHEST, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> OBSIDIAN_CHESTPLATE = ITEMS.register("obsidian_chestplate", () -> new ArmorItem(ModArmorMaterials.OBSIDIAN, EquipmentSlotType.CHEST, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> REDSTONE_CHESTPLATE = ITEMS.register("redstone_chestplate", () -> new ArmorItem(ModArmorMaterials.REDSTONE, EquipmentSlotType.CHEST, (new Item.Properties()).tab(ITEM_GROUP)));
 
-    public static final RegistryObject<ArmorItem> EMERALD_LEGGINGS = ITEMS.register("emerald_leggings", () -> new ArmorItem(ModArmorMaterials.EMERALD, EquipmentSlotType.LEGS, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> LAPIS_LEGGINGS = ITEMS.register("lapis_leggings", () -> new ArmorItem(ModArmorMaterials.LAPIS, EquipmentSlotType.LEGS, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> OBSIDIAN_LEGGINGS = ITEMS.register("obsidian_leggings", () -> new ArmorItem(ModArmorMaterials.OBSIDIAN, EquipmentSlotType.LEGS, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> REDSTONE_LEGGINGS = ITEMS.register("redstone_leggings", () -> new ArmorItem(ModArmorMaterials.REDSTONE, EquipmentSlotType.LEGS, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
+    public static final RegistryObject<ArmorItem> EMERALD_LEGGINGS = ITEMS.register("emerald_leggings", () -> new ArmorItem(ModArmorMaterials.EMERALD, EquipmentSlotType.LEGS, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> LAPIS_LEGGINGS = ITEMS.register("lapis_leggings", () -> new ArmorItem(ModArmorMaterials.LAPIS, EquipmentSlotType.LEGS, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> OBSIDIAN_LEGGINGS = ITEMS.register("obsidian_leggings", () -> new ArmorItem(ModArmorMaterials.OBSIDIAN, EquipmentSlotType.LEGS, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> REDSTONE_LEGGINGS = ITEMS.register("redstone_leggings", () -> new ArmorItem(ModArmorMaterials.REDSTONE, EquipmentSlotType.LEGS, (new Item.Properties()).tab(ITEM_GROUP)));
 
-    public static final RegistryObject<ArmorItem> EMERALD_BOOTS = ITEMS.register("emerald_boots", () -> new ArmorItem(ModArmorMaterials.EMERALD, EquipmentSlotType.FEET, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> LAPIS_BOOTS = ITEMS.register("lapis_boots", () -> new ArmorItem(ModArmorMaterials.LAPIS, EquipmentSlotType.FEET, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> OBSIDIAN_BOOTS = ITEMS.register("obsidian_boots", () -> new ArmorItem(ModArmorMaterials.OBSIDIAN, EquipmentSlotType.FEET, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<ArmorItem> REDSTONE_BOOTS = ITEMS.register("redstone_boots", () -> new ArmorItem(ModArmorMaterials.REDSTONE, EquipmentSlotType.FEET, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
+    public static final RegistryObject<ArmorItem> EMERALD_BOOTS = ITEMS.register("emerald_boots", () -> new ArmorItem(ModArmorMaterials.EMERALD, EquipmentSlotType.FEET, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> LAPIS_BOOTS = ITEMS.register("lapis_boots", () -> new ArmorItem(ModArmorMaterials.LAPIS, EquipmentSlotType.FEET, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> OBSIDIAN_BOOTS = ITEMS.register("obsidian_boots", () -> new ArmorItem(ModArmorMaterials.OBSIDIAN, EquipmentSlotType.FEET, (new Item.Properties()).tab(ITEM_GROUP)));
+    public static final RegistryObject<ArmorItem> REDSTONE_BOOTS = ITEMS.register("redstone_boots", () -> new ArmorItem(ModArmorMaterials.REDSTONE, EquipmentSlotType.FEET, (new Item.Properties()).tab(ITEM_GROUP)));
 }

--- a/src/main/java/moretoolmaterials/registry/ToolRegistry.java
+++ b/src/main/java/moretoolmaterials/registry/ToolRegistry.java
@@ -11,28 +11,28 @@ public class ToolRegistry
 {
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MoreToolMaterials.MOD_ID);
 
-    public static final RegistryObject<SwordItem> EMERALD_SWORD = ITEMS.register("emerald_sword", () -> new SwordItem(ModItemTiers.EMERALD, 3, -2.4F, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<SwordItem> LAPIS_SWORD = ITEMS.register("lapis_sword", () -> new SwordItem(ModItemTiers.LAPIS, 3, -2.4F, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<SwordItem> OBSIDIAN_SWORD = ITEMS.register("obsidian_sword", () -> new SwordItem(ModItemTiers.OBSIDIAN, 3, -2.4F, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
-    public static final RegistryObject<SwordItem> REDSTONE_SWORD = ITEMS.register("redstone_sword", () -> new SwordItem(ModItemTiers.REDSTONE, 3, -2.4F, (new Item.Properties()).tab(ItemGroup.TAB_COMBAT)));
+    public static final RegistryObject<SwordItem> EMERALD_SWORD = ITEMS.register("emerald_sword", () -> new SwordItem(ModItemTiers.EMERALD, 3, -2.4F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<SwordItem> LAPIS_SWORD = ITEMS.register("lapis_sword", () -> new SwordItem(ModItemTiers.LAPIS, 3, -2.4F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<SwordItem> OBSIDIAN_SWORD = ITEMS.register("obsidian_sword", () -> new SwordItem(ModItemTiers.OBSIDIAN, 3, -2.4F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<SwordItem> REDSTONE_SWORD = ITEMS.register("redstone_sword", () -> new SwordItem(ModItemTiers.REDSTONE, 3, -2.4F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
 
-    public static final RegistryObject<ShovelItem> EMERALD_SHOVEL = ITEMS.register("emerald_shovel", () -> new ShovelItem(ModItemTiers.EMERALD, 1.5F, -3.0F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<ShovelItem> LAPIS_SHOVEL = ITEMS.register("lapis_shovel", () -> new ShovelItem(ModItemTiers.LAPIS, 1.5F, -3.0F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<ShovelItem> OBSIDIAN_SHOVEL = ITEMS.register("obsidian_shovel", () -> new ShovelItem(ModItemTiers.OBSIDIAN, 1.5F, -3.0F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<ShovelItem> REDSTONE_SHOVEL = ITEMS.register("redstone_shovel", () -> new ShovelItem(ModItemTiers.REDSTONE, 1.5F, -3.0F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
+    public static final RegistryObject<ShovelItem> EMERALD_SHOVEL = ITEMS.register("emerald_shovel", () -> new ShovelItem(ModItemTiers.EMERALD, 1.5F, -3.0F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<ShovelItem> LAPIS_SHOVEL = ITEMS.register("lapis_shovel", () -> new ShovelItem(ModItemTiers.LAPIS, 1.5F, -3.0F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<ShovelItem> OBSIDIAN_SHOVEL = ITEMS.register("obsidian_shovel", () -> new ShovelItem(ModItemTiers.OBSIDIAN, 1.5F, -3.0F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<ShovelItem> REDSTONE_SHOVEL = ITEMS.register("redstone_shovel", () -> new ShovelItem(ModItemTiers.REDSTONE, 1.5F, -3.0F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
 
-    public static final RegistryObject<PickaxeItem> EMERALD_PICKAXE = ITEMS.register("emerald_pickaxe", () -> new PickaxeItem(ModItemTiers.EMERALD, 1, -2.8F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<PickaxeItem> LAPIS_PICKAXE = ITEMS.register("lapis_pickaxe", () -> new PickaxeItem(ModItemTiers.LAPIS, 1, -2.8F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<PickaxeItem> OBSIDIAN_PICKAXE = ITEMS.register("obsidian_pickaxe", () -> new PickaxeItem(ModItemTiers.OBSIDIAN, 1, -2.8F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<PickaxeItem> REDSTONE_PICKAXE = ITEMS.register("redstone_pickaxe", () -> new PickaxeItem(ModItemTiers.REDSTONE, 1, -2.8F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
+    public static final RegistryObject<PickaxeItem> EMERALD_PICKAXE = ITEMS.register("emerald_pickaxe", () -> new PickaxeItem(ModItemTiers.EMERALD, 1, -2.8F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<PickaxeItem> LAPIS_PICKAXE = ITEMS.register("lapis_pickaxe", () -> new PickaxeItem(ModItemTiers.LAPIS, 1, -2.8F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<PickaxeItem> OBSIDIAN_PICKAXE = ITEMS.register("obsidian_pickaxe", () -> new PickaxeItem(ModItemTiers.OBSIDIAN, 1, -2.8F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<PickaxeItem> REDSTONE_PICKAXE = ITEMS.register("redstone_pickaxe", () -> new PickaxeItem(ModItemTiers.REDSTONE, 1, -2.8F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
 
-    public static final RegistryObject<AxeItem> EMERALD_AXE = ITEMS.register("emerald_axe", () -> new AxeItem(ModItemTiers.EMERALD, 5.0F, -3.0F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<AxeItem> LAPIS_AXE = ITEMS.register("lapis_axe", () -> new AxeItem(ModItemTiers.LAPIS, 4.5F, -3.0F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<AxeItem> OBSIDIAN_AXE = ITEMS.register("obsidian_axe", () -> new AxeItem(ModItemTiers.OBSIDIAN, 7.0F, -3.2F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<AxeItem> REDSTONE_AXE = ITEMS.register("redstone_axe", () -> new AxeItem(ModItemTiers.REDSTONE, 4.0F, -3.0F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
+    public static final RegistryObject<AxeItem> EMERALD_AXE = ITEMS.register("emerald_axe", () -> new AxeItem(ModItemTiers.EMERALD, 5.0F, -3.0F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<AxeItem> LAPIS_AXE = ITEMS.register("lapis_axe", () -> new AxeItem(ModItemTiers.LAPIS, 4.5F, -3.0F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<AxeItem> OBSIDIAN_AXE = ITEMS.register("obsidian_axe", () -> new AxeItem(ModItemTiers.OBSIDIAN, 7.0F, -3.2F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<AxeItem> REDSTONE_AXE = ITEMS.register("redstone_axe", () -> new AxeItem(ModItemTiers.REDSTONE, 4.0F, -3.0F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
 
-    public static final RegistryObject<HoeItem> EMERALD_HOE = ITEMS.register("emerald_hoe", () -> new HoeItem(ModItemTiers.EMERALD, -3, 0.0F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<HoeItem> LAPIS_HOE = ITEMS.register("lapis_hoe", () -> new HoeItem(ModItemTiers.LAPIS, -2, 0.0F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<HoeItem> OBSIDIAN_HOE = ITEMS.register("obsidian_hoe", () -> new HoeItem(ModItemTiers.OBSIDIAN, -4, 0.0F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
-    public static final RegistryObject<HoeItem> REDSTONE_HOE = ITEMS.register("redstone_hoe", () -> new HoeItem(ModItemTiers.REDSTONE, -2, 0.0F, (new Item.Properties()).tab(ItemGroup.TAB_TOOLS)));
+    public static final RegistryObject<HoeItem> EMERALD_HOE = ITEMS.register("emerald_hoe", () -> new HoeItem(ModItemTiers.EMERALD, -3, 0.0F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<HoeItem> LAPIS_HOE = ITEMS.register("lapis_hoe", () -> new HoeItem(ModItemTiers.LAPIS, -2, 0.0F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<HoeItem> OBSIDIAN_HOE = ITEMS.register("obsidian_hoe", () -> new HoeItem(ModItemTiers.OBSIDIAN, -4, 0.0F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
+    public static final RegistryObject<HoeItem> REDSTONE_HOE = ITEMS.register("redstone_hoe", () -> new HoeItem(ModItemTiers.REDSTONE, -2, 0.0F, (new Item.Properties()).tab(ArmorRegistry.ITEM_GROUP)));
 }


### PR DESCRIPTION
Just a small commit that moves all tools and armor to a separate item group tab.

By the way, have you thought about giving the custom tools and armor special effects to separate them from vanilla? Something like maybe making the redstone tools/armor more powerful if you are standing on a redstonepowered block, or making endermen not aggro you if you are wearing full obsidian armor etc. Or maybe I am just overthinking things? :P